### PR TITLE
Dynamic counter based queues

### DIFF
--- a/src/jobs_server.erl
+++ b/src/jobs_server.erl
@@ -521,7 +521,7 @@ i_handle_call({set_modifiers, Modifiers}, _, #st{queues     = Qs,
 i_handle_call({add_queue, Name, Options}, _, #st{queues = Qs} = S) ->
     false = get_queue(Name, Qs),
     NewQueues = init_queues([{Name, Options}], S),
-    {reply, ok, S#st{queues = Qs ++ NewQueues}};
+    {reply, ok, lift_counters(S#st{queues = Qs ++ NewQueues})};
 i_handle_call({delete_queue, Name}, _, #st{queues = Qs} = S) ->
     case get_queue(Name, Qs) of
         false ->


### PR DESCRIPTION
Hi there, I noticed adding counter based queues at runtime didn't work correctly. The counter #cr{} was left in the queue definition instead of being added to the list of counters. Doing jobs:add_queue(cassandra, [{regulators, [{counter, [{limit, 120}, {modifiers, [{cpu, 10}, {mem, 10}]}]}]}]) gave the following:
    {queue,[{name,cassandra},
             {mod,jobs_queue},
             {type,fifo},
             {group,undefined},
             {regulators,[{cr,[{name,{counter,cassandra,1}},
                               {increment,1},
                               {value,0},
                               {rate,{rate,[{limit,120},
                                            {preset_limit,120},
                                            {interval,20000},
                                            {modifiers,[]},
                                            {active_modifiers,[]}]}},
                               {queues,[]},
                               {shared,false}]}]},
             {max_time,undefined},
             {max_size,undefined},
             {latest_dispatch,0},
             {check_interval,20},
             {oldest_job,undefined},
             {timer,undefined},
             {st,{st,20503}}]}

instead of:
    {queue,[{name,cassandra},
            {mod,jobs_queue},
            {type,fifo},
            {group,undefined},
            {regulators,[{counter,{counter,cassandra,1},1}]},
            {max_time,undefined},
            {max_size,undefined},
            {latest_dispatch,31521552871022},
            {check_interval,20},
            {oldest_job,undefined},
            {timer,undefined},
            {st,{st,110612}}]}

Doing lift_counters after init_queue seems to do the right thing (though I don't understand the whole codebase yet).
