### PR TITLE
Fixes is_overload/0 in jobs_sampler_mnesia.erl

### DIFF
--- a/src/jobs_sampler_mnesia.erl
+++ b/src/jobs_sampler_mnesia.erl
@@ -68,12 +68,7 @@ subscriber_loop(Name) ->
 
 is_overload() ->
     %% e.g: [{mnesia_tm,true},{mnesia_dump_log,false}]
-    case lists:keysearch(true, 2, mnesia_overload_read()) of
-        [] ->
-            false;
-        _ ->
-            true
-    end.
+    lists:keymember(true, 2, mnesia_overload_read()).
 
 mnesia_overload_read() ->
     %% This function is not present in mnesia versions older than R14A

--- a/src/jobs_sampler_mnesia.erl
+++ b/src/jobs_sampler_mnesia.erl
@@ -67,8 +67,8 @@ subscriber_loop(Name) ->
 
 
 is_overload() ->
-    %% FIX THIS!!!!
-    case mnesia_overload_read() of
+    %% e.g: [{mnesia_tm,true},{mnesia_dump_log,false}]
+    case lists:keysearch(true, 2, mnesia_overload_read()) of
         [] ->
             false;
         _ ->


### PR DESCRIPTION
removes use of case, uses lists:keymember/3 instead to check if any mnesia overload set to true.
