### PR TITLE
Eqc queue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DIALYZER=dialyzer
 
-.PHONY: all test clean plt analyze doc
+.PHONY: all test clean plt analyze doc test-console
 
 all: deps compile
 
@@ -18,6 +18,9 @@ clean:
 
 doc:
 	rebar doc
+
+test-console:
+	erl -pa deps/*/ebin ebin
 
 plt: deps compile
 	$(DIALYZER) --build_plt --output_plt .jobs.plt \

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ doc:
 	rebar doc
 
 test-console:
-	erl -pa deps/*/ebin ebin
+	erlc -I include -o test test/*.erl
+	erl -pa deps/*/ebin ebin test
 
 plt: deps compile
 	$(DIALYZER) --build_plt --output_plt .jobs.plt \

--- a/TODO.org
+++ b/TODO.org
@@ -1,5 +1,8 @@
-* Change jobs_eqc_model so it understands LIFO and FIFO.
-* Change test so we always generate fifo with jobs queue
-* Change test so we always generate life with jobs queue list
-* Add tests for the "timedout" parameter.
+* DONE Change jobs_eqc_model so it understands LIFO and FIFO.
+* DONE Change test so we always generate fifo with jobs queue
+* DONE Change test so we always generate life with jobs queue list
+* TODO Add tests for the "timedout" parameter.
+** DONE Implement timedout in the model
+** TODO Introduce meck
+** TODO Meck up jobs_lib:timestamp()
 

--- a/TODO.org
+++ b/TODO.org
@@ -1,0 +1,5 @@
+* Change jobs_eqc_model so it understands LIFO and FIFO.
+* Change test so we always generate fifo with jobs queue
+* Change test so we always generate life with jobs queue list
+* Add tests for the "timedout" parameter.
+

--- a/include/jobs.hrl
+++ b/include/jobs.hrl
@@ -101,7 +101,7 @@
 
 -record(queue, {name                 :: any(),
 		mod                  :: atom(),
-		type = fifo          :: fifo | #producer{} | #passive{}
+		type = fifo          :: fifo | lifo | #producer{} | #passive{}
 				      | #action{},
 		group                :: atom(),
 		regulators  = []     :: [regulator() | regulator_ref()],

--- a/rebar.config
+++ b/rebar.config
@@ -8,6 +8,8 @@
 {clean_files, ["*~","*/*~","*/*.xfm","test/*.beam"]}.
 
 {deps, [
+        {meck, ".*",
+         {git, "git://github.com/eproxus/meck.git", "HEAD"}},
         {parse_trans, ".*",
          {git, "git://github.com/esl/parse_trans.git", "HEAD"}},
 	{edown, ".*",

--- a/src/jobs_queue.erl
+++ b/src/jobs_queue.erl
@@ -93,7 +93,7 @@ representation(
            st = #st { table = Tab}}) ->
     Contents = ets:match_object(Tab, '$1'),
     [{oldest_job, OJ},
-     {contents, Contents}].
+     {contents, [X || {X} <- Contents]}].
 
 %% @spec delete(#queue{}) -> any()
 %% @doc Queue is being deleted; remove any external data structures.

--- a/src/jobs_queue.erl
+++ b/src/jobs_queue.erl
@@ -36,11 +36,12 @@
          delete/1]).
 -export([in/3,
          out/2,
-	 peek/1,
+         peek/1,
          info/2,
          all/1,
          empty/1,
          is_empty/1,
+         representation/1,
          timedout/1, timedout/2]).
 
 -export([behaviour_info/1]).
@@ -84,6 +85,15 @@ new(Options, Q) ->
             Tab = ets:new(?MODULE, [ordered_set]),
             Q#queue{st = #st{table = Tab}}
     end.
+
+%% @doc A representation of a queue which can be inspected
+%% @end
+representation(
+  #queue { oldest_job = OJ,
+           st = #st { table = Tab}}) ->
+    Contents = ets:match_object(Tab, '$1'),
+    [{oldest_job, OJ},
+     {contents, Contents}].
 
 %% @spec delete(#queue{}) -> any()
 %% @doc Queue is being deleted; remove any external data structures.

--- a/src/jobs_queue.erl
+++ b/src/jobs_queue.erl
@@ -132,9 +132,9 @@ in(TS, Job, #queue{st = #st{table = Tab}, oldest_job = OJ} = Q) ->
 peek(#queue{st = #st{table = T}}) ->
     case ets:first(T) of
 	'$end_of_table' ->
-	    undefined;
+            undefined;
 	Key ->
-	    Key
+            Key
     end.
 
 -spec out(N :: integer(), #queue{}) -> {[entry()], #queue{}}.

--- a/src/jobs_queue.erl
+++ b/src/jobs_queue.erl
@@ -232,7 +232,7 @@ set_oldest_job(#queue{st = #st{table = Tab}} = Q) ->
             
 
 find_expired(Tab, Now, TO) ->
-    find_expired(ets:last(Tab), Tab, Now, TO, [], undefined).
+    find_expired(ets:first(Tab), Tab, Now, TO, [], undefined).
 
 %% we return the reversed list, but I don't think that matters here.
 find_expired('$end_of_table', _, _, _, Acc, OJ) ->
@@ -240,10 +240,10 @@ find_expired('$end_of_table', _, _, _, Acc, OJ) ->
 find_expired({TS, _} = Key, Tab, Now, TO, Acc, _OJ) ->
     case is_expired(TS, Now, TO) of
 	true ->
-	    ets:delete(Tab, Key),
-	    find_expired(ets:last(Tab), Tab, Now, TO, [Key|Acc], TS);
+            ets:delete(Tab, Key),
+            find_expired(ets:first(Tab), Tab, Now, TO, [Key|Acc], TS);
 	false ->
-	    {Acc, TS}
+            {Acc, TS}
     end.
 
 empty(#queue{st = #st{table = T}} = Q) ->

--- a/src/jobs_queue_list.erl
+++ b/src/jobs_queue_list.erl
@@ -36,6 +36,7 @@
          all/1,
          empty/1,
          is_empty/1,
+         representation/1,
          timedout/1, timedout/2]).
 
 -include("jobs.hrl").
@@ -73,6 +74,10 @@ out(N, #queue{st = L, oldest_job = OJ} = Q) when N >= 0 ->
 	      _  -> OJ
 	  end,
     {Out, Q#queue{st = Rest, oldest_job = OJ1}}.
+
+representation(#queue { st = L, oldest_job = OJ}) ->
+    [{oldest_job, OJ},
+     {contents, L}].
 
 split(N, L) ->
     split(N, L, []).

--- a/src/jobs_queue_list.erl
+++ b/src/jobs_queue_list.erl
@@ -32,6 +32,7 @@
 -export([in/3,
          out/2,
          info/2,
+         peek/1,
          all/1,
          empty/1,
          is_empty/1,
@@ -84,6 +85,8 @@ split(0, T, Acc) ->
     {lists:reverse(Acc), T}.
 
 
+peek(#queue{st = []})        -> undefined;
+peek(#queue { st = [H | _]}) -> H.
 
 
 -spec all(#queue{}) -> [entry()].

--- a/src/jobs_queue_list.erl
+++ b/src/jobs_queue_list.erl
@@ -40,7 +40,6 @@
          timedout/1, timedout/2]).
 
 -include("jobs.hrl").
--import(jobs_lib, [timestamp/0]).
 
 %-type timestamp() :: integer().
 -type job()       :: {pid(), reference()}.
@@ -123,10 +122,10 @@ timedout(#queue{max_time = TO} = Q) ->
 
 timedout(_ , #queue{oldest_job = undefined}) -> [];
 timedout(TO, #queue{st = L} = Q) ->
-    Now = timestamp(),
+    Now = jobs_lib:timestamp(),
     {Left, Timedout} = lists:splitwith(fun({TS,_}) ->
-					       not(is_expired(TS,Now,TO)) 
-				       end, L),
+                                               not(is_expired(TS,Now,TO)) 
+                                       end, L),
     OJ = get_oldest_job(Left),
     {Timedout, Q#queue{oldest_job = OJ, st = Left}}.
 

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -58,7 +58,7 @@ g_model(N, Ty) ->
                                  [M, g_time_advance()]}},
                           {200, {call, ?MODULE, in, [Ty, g_job(), M]}},
                           {100, {call, ?MODULE, out, [Ty, choose(0,100), M]}},
-%%                          {20,  {call, ?MODULE, timedout, [Ty, M]}},
+                          {20,  {call, ?MODULE, timedout, [Ty, M]}},
                           {1,   {call, ?MODULE, empty, [Ty, M]}}
                          ]))}
               ]).

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -38,7 +38,7 @@ g_time_advance() ->
     ?LET(N, nat(), N+1).
 
 g_model_type() ->
-    oneof([jobs_queue_list]).
+    oneof([jobs_queue_list, jobs_queue]).
 
 g_model(Ty) ->
     ?SIZED(Size, g_model(Size, Ty)).
@@ -57,8 +57,8 @@ g_model(N, Ty) ->
                           {200, {call, ?MODULE, advance_time,
                                  [M, g_time_advance()]}},
                           {200, {call, ?MODULE, in, [Ty, g_job(), M]}},
-                          {100, {call, ?MODULE, out, [Ty, nat(), M]}},
-                          {20,  {call, ?MODULE, timedout, [Ty, M]}},
+                          {100, {call, ?MODULE, out, [Ty, choose(0,100), M]}},
+%%                          {20,  {call, ?MODULE, timedout, [Ty, M]}},
                           {1,   {call, ?MODULE, empty, [Ty, M]}}
                          ]))}
               ]).

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -14,12 +14,16 @@ g_scheduling_order() ->
 g_options() ->
     [g_scheduling_order()].
 
+g_queue_record() ->
+    ?LET(N, nat(),
+        #queue { max_time = N }).
+
 g_queue() ->
     ?SIZED(Size, g_queue(Size)).
 
 g_queue(0) ->
     oneof([{call, jobs_queue, new, [g_options(),
-                                    #queue{}]}]);
+                                    g_queue_record()]}]);
 g_queue(N) ->
     frequency([{1, g_queue(0)},
                {N,
@@ -34,9 +38,14 @@ g_queue(N) ->
 out(N, Q) ->
     element(2, jobs_queue:out(N, Q)).
 
+g_info() ->
+    oneof([oldest_job, length, max_time]).
+
 obs() ->
     Q = g_queue(),
-    oneof([{call, jobs_queue, is_empty, [Q]}]).
+    oneof([{call, jobs_queue, all, [Q]},
+           {call, jobs_queue, info, [g_info(), Q]},
+           {call, jobs_queue, is_empty, [Q]}]).
 
 model({call, _, F, Args}) ->
     apply(jobs_queue_model, F, model(Args));

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -29,11 +29,12 @@ g_queue(N) ->
                {N,
                   ?LET(Q, g_queue(max(0, N-2)),
                        frequency(
-                         [{2, oneof(
-                                [{call, jobs_queue, in, [0,
-                                                         g_job(), Q]}])},
-                          {1, oneof(
-                               [{call, ?MODULE, out, [nat(), Q]}])}]))}]).
+                         [
+                          {200, {call, jobs_queue, in, [0, g_job(), Q]}},
+                          {100, {call, ?MODULE, out, [nat(), Q]}},
+                          {1,   {call, jobs_queue, empty, [Q]}}
+                         ]))}
+              ]).
 
 out(N, Q) ->
     element(2, jobs_queue:out(N, Q)).

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -15,8 +15,8 @@ g_job() ->
 g_scheduling_order() ->
     elements([fifo, lifo]).
 
-g_options() ->
-    [g_scheduling_order()].
+g_options(jobs_queue) -> return([fifo]);
+g_options(jobs_queue_list) -> return([lifo]).
 
 g_queue_record() ->
     ?LET(N, nat(),
@@ -27,14 +27,14 @@ g_start_time() ->
          T + N).
 
 g_model_type() ->
-    oneof([jobs_queue, jobs_queue_list]).
+    oneof([jobs_queue]).
 
 g_model(Ty) ->
     ?SIZED(Size, g_model(Size, Ty)).
 
 g_model(0, Ty) ->
     oneof([{call, ?MODULE, new, [Ty,
-                                 g_options(),
+                                 g_options(Ty),
                                  g_queue_record(),
                                  g_start_time()]}]);
 g_model(N, Ty) ->

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -1,0 +1,61 @@
+-module(jobs_eqc_queue).
+
+-include_lib("eqc/include/eqc.hrl").
+-include("jobs.hrl").
+
+-compile(export_all).
+
+g_job() ->
+    {make_ref(), make_ref()}.
+
+g_scheduling_order() ->
+    elements([fifo, lifo]).
+
+g_options() ->
+    [g_scheduling_order()].
+
+g_queue() ->
+    ?SIZED(Size, g_queue(Size)).
+
+g_queue(0) ->
+    oneof([{call, jobs_queue, new, [g_options(),
+                                    #queue{}]}]);
+g_queue(N) ->
+    frequency([{1, g_queue(0)},
+               {N,
+                  ?LET(Q, g_queue(max(0, N-2)),
+                       frequency(
+                         [{2, oneof(
+                                [{call, jobs_queue, in, [0,
+                                                         g_job(), Q]}])},
+                          {1, oneof(
+                               [{call, jobs_queue, out, [nat(), Q]}])}]))}]).
+
+obs() ->
+    Q = g_queue(),
+    oneof([{call, jobs_queue, is_empty, [Q]}]).
+
+model({call, F, Args}) ->
+    apply(jobs_queue_model, F, model(Args));
+model([H|T]) ->
+    [model(H) | model(T)];
+model(X) ->
+    X.
+
+prop_queue() ->
+    ?FORALL(Q, g_queue(),
+            equals(
+              catching(fun() -> jobs_queue:representation(
+                                  eval(Q))
+                       end, e),
+              catching(fun () -> jobs_queue_model:representation(
+                                   model(Q))
+                       end, q))).
+
+catching(F, T) ->
+        try F()
+        catch C:E ->
+                io:format("Exception: ~p:~p", [C, E]),
+                T
+        end.
+

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -40,7 +40,7 @@ g_model(N) ->
                   ?LET(M, g_model(max(0, N-2)),
                        frequency(
                          [
-                          %{300, {call, ?MODULE, advance_time, [M, nat()]}},
+                          {300, {call, ?MODULE, advance_time, [M, nat()]}},
                           {200, {call, ?MODULE, in, [jobs_queue, g_job(), M]}},
                           {100, {call, ?MODULE, out, [jobs_queue, nat(), M]}},
                           {1,   {call, ?MODULE, empty, [jobs_queue, M]}}

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -40,7 +40,7 @@ g_model(N) ->
                   ?LET(M, g_model(max(0, N-2)),
                        frequency(
                          [
-                          {300, {call, ?MODULE, advance_time, [M, nat()]}},
+                          {200, {call, ?MODULE, advance_time, [M, nat()]}},
                           {200, {call, ?MODULE, in, [jobs_queue, g_job(), M]}},
                           {100, {call, ?MODULE, out, [jobs_queue, nat(), M]}},
                           {1,   {call, ?MODULE, empty, [jobs_queue, M]}}

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -29,7 +29,10 @@ g_queue(N) ->
                                 [{call, jobs_queue, in, [0,
                                                          g_job(), Q]}])},
                           {1, oneof(
-                               [{call, jobs_queue, out, [nat(), Q]}])}]))}]).
+                               [{call, ?MODULE, out, [nat(), Q]}])}]))}]).
+
+out(N, Q) ->
+    element(2, jobs_queue:out(N, Q)).
 
 obs() ->
     Q = g_queue(),

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -35,7 +35,7 @@ obs() ->
     Q = g_queue(),
     oneof([{call, jobs_queue, is_empty, [Q]}]).
 
-model({call, F, Args}) ->
+model({call, _, F, Args}) ->
     apply(jobs_queue_model, F, model(Args));
 model([H|T]) ->
     [model(H) | model(T)];

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -44,6 +44,7 @@ g_info() ->
 obs() ->
     Q = g_queue(),
     oneof([{call, jobs_queue, all, [Q]},
+           {call, jobs_queue, peek, [Q]},
            {call, jobs_queue, info, [g_info(), Q]},
            {call, jobs_queue, is_empty, [Q]}]).
 

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -38,7 +38,7 @@ g_time_advance() ->
     ?LET(N, nat(), N+1).
 
 g_model_type() ->
-    oneof([jobs_queue, jobs_queue_list]).
+    oneof([jobs_queue_list]).
 
 g_model(Ty) ->
     ?SIZED(Size, g_model(Size, Ty)).
@@ -58,7 +58,7 @@ g_model(N, Ty) ->
                                  [M, g_time_advance()]}},
                           {200, {call, ?MODULE, in, [Ty, g_job(), M]}},
                           {100, {call, ?MODULE, out, [Ty, nat(), M]}},
-                          %%{20,  {call, ?MODULE, timedout, [Ty, M]}},
+                          {20,  {call, ?MODULE, timedout, [Ty, M]}},
                           {1,   {call, ?MODULE, empty, [Ty, M]}}
                          ]))}
               ]).
@@ -125,7 +125,7 @@ obs() ->
              oneof([{call, ?MODULE, all, [Ty, M]},
                     {call, ?MODULE, peek, [Ty, M]},
                     {call, ?MODULE, info, [Ty, g_info(), M]},
-%%                    {call, ?MODULE, timedout_obs, [Ty, M]},
+                    {call, ?MODULE, timedout_obs, [Ty, M]},
                     {call, ?MODULE, is_empty, [Ty, M]}])
          end).
 

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -83,7 +83,7 @@ timedout_obs(Mod, #model { st = Q} = M) ->
     set_time(M),
     case Mod:timedout(Q) of
         [] -> [];
-        {TO, _} -> TO
+        {TO, _} -> lists:sort(TO)
     end.
 
 in(Mod, Job, #model { time = T, st = Q} = M) ->
@@ -162,23 +162,22 @@ prop_queue() ->
               catching(fun() ->
                                R = eval(M),
                                Ty:representation(R#model.st)
-                       end, e),
+                       end),
               catching(fun () ->
                                R = model(M),
                                jobs_queue_model:representation(R#model.st)
-                       end, q)))).
+                       end)))).
 
 prop_observe() ->
     ?FORALL(Obs, obs(),
             equals(
-              catching(fun() -> eval(Obs) end, e),
-              catching(fun() -> model(Obs) end, m))).
+              catch eval(Obs),
+              catch model(Obs))).
 
-catching(F, T) ->
+catching(F) ->
         try F()
         catch C:E ->
-                io:format("Exception: ~p:~p~n", [C, E]),
-                T
+                {exception, C, E}
         end.
 
 set_time(#model { time = T}) ->

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -15,8 +15,8 @@ g_job() ->
 g_scheduling_order() ->
     elements([fifo, lifo]).
 
-g_options(jobs_queue) -> return([fifo]);
-g_options(jobs_queue_list) -> return([lifo]).
+g_options(jobs_queue) -> return([{type, fifo}]);
+g_options(jobs_queue_list) -> return([{type, lifo}]).
 
 g_queue_record() ->
     ?LET(N, nat(),

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -55,6 +55,12 @@ prop_queue() ->
                                    model(Q))
                        end, q))).
 
+prop_observe() ->
+    ?FORALL(Obs, obs(),
+            equals(
+              catching(fun() -> eval(Obs) end, e),
+              catching(fun() -> model(Obs) end, m))).
+
 catching(F, T) ->
         try F()
         catch C:E ->

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -46,6 +46,7 @@ g_model(N, Ty) ->
                           {200, {call, ?MODULE, advance_time, [M, nat()]}},
                           {200, {call, ?MODULE, in, [Ty, g_job(), M]}},
                           {100, {call, ?MODULE, out, [Ty, nat(), M]}},
+%%                          {20,  {call, ?MODULE, timedout, [Ty, M]}},
                           {1,   {call, ?MODULE, empty, [Ty, M]}}
                          ]))}
               ]).
@@ -56,6 +57,14 @@ new(Mod, Opts, Q, T) ->
 
 advance_time(#model { time = T} = M, N) ->
     M#model { time = T + N}.
+
+timedout(Mod, #model { st = Q} = M) ->
+    {_, NQ} = Mod:timedout(Q),
+    M#model { st = NQ }.
+
+timedout_obs(Mod, #model { st = Q}) ->
+    {TO, _} = Mod:timedout(Q),
+    TO.
 
 in(Mod, Job, #model { time = T, st = Q} = M) ->
     M#model { st = Mod:in(T, Job, Q)}.
@@ -89,6 +98,7 @@ obs() ->
              oneof([{call, ?MODULE, all, [Ty, M]},
                     {call, ?MODULE, peek, [Ty, M]},
                     {call, ?MODULE, info, [Ty, g_info(), M]},
+%%                    {call, ?MODULE, timedout_obs, [Ty, M]},
                     {call, ?MODULE, is_empty, [Ty, M]}])
          end).
 

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -5,6 +5,10 @@
 
 -compile(export_all).
 
+-record(model,
+        { time = jobs_lib:timestamp(),
+          st   = undefined }).
+
 g_job() ->
     {make_ref(), make_ref()}.
 
@@ -18,52 +22,104 @@ g_queue_record() ->
     ?LET(N, nat(),
         #queue { max_time = N }).
 
-g_queue() ->
-    ?SIZED(Size, g_queue(Size)).
+g_start_time() ->
+    ?LET({T, N}, {jobs_lib:timestamp(), nat()},
+         T + N).
 
-g_queue(0) ->
-    oneof([{call, jobs_queue, new, [g_options(),
-                                    g_queue_record()]}]);
-g_queue(N) ->
-    frequency([{1, g_queue(0)},
+g_model() ->
+    ?SIZED(Size, g_model(Size)).
+
+g_model(0) ->
+    oneof([{call, ?MODULE, new, [jobs_queue,
+                                 g_options(),
+                                 g_queue_record(),
+                                 g_start_time()]}]);
+g_model(N) ->
+    frequency([{1, g_model(0)},
                {N,
-                  ?LET(Q, g_queue(max(0, N-2)),
+                  ?LET(M, g_model(max(0, N-2)),
                        frequency(
                          [
-                          {200, {call, jobs_queue, in, [0, g_job(), Q]}},
-                          {100, {call, ?MODULE, out, [nat(), Q]}},
-                          {1,   {call, jobs_queue, empty, [Q]}}
+                          %{300, {call, ?MODULE, advance_time, [M, nat()]}},
+                          {200, {call, ?MODULE, in, [jobs_queue, g_job(), M]}},
+                          {100, {call, ?MODULE, out, [jobs_queue, nat(), M]}},
+                          {1,   {call, ?MODULE, empty, [jobs_queue, M]}}
                          ]))}
               ]).
 
-out(N, Q) ->
-    element(2, jobs_queue:out(N, Q)).
+new(Mod, Opts, Q, T) ->
+    #model { st = Mod:new(Opts, Q),
+             time = T}.
+
+advance_time(#model { time = T} = M, N) ->
+    M#model { time = T + N}.
+
+in(Mod, Job, #model { time = T, st = Q} = M) ->
+    M#model { st = Mod:in(T, Job, Q)}.
+
+out(Mod, N, #model { st = Q} = M) ->
+    NQ = element(2, Mod:out(N, Q)),
+    M#model { st = NQ }.
+
+empty(Mod, #model { st = Q} = M) ->
+    M#model { st = Mod:empty(Q)}.
+
+is_empty(M, #model { st = Q}) ->
+    M:is_empty(Q).
+
+peek(M, #model { st = Q}) ->
+    M:peek(Q).
+
+all(M, #model { st = Q}) ->
+    M:all(Q).
+
+info(M, I, #model { st = Q}) ->
+    M:info(I, Q).
 
 g_info() ->
     oneof([oldest_job, length, max_time]).
 
 obs() ->
-    Q = g_queue(),
-    oneof([{call, jobs_queue, all, [Q]},
-           {call, jobs_queue, peek, [Q]},
-           {call, jobs_queue, info, [g_info(), Q]},
-           {call, jobs_queue, is_empty, [Q]}]).
+    M = g_model(),
+    oneof([{call, ?MODULE, all, [jobs_queue, M]},
+           {call, ?MODULE, peek, [jobs_queue, M]},
+           {call, ?MODULE, info, [jobs_queue, g_info(), M]},
+           {call, ?MODULE, is_empty, [jobs_queue, M]}]).
 
-model({call, _, F, Args}) ->
-    apply(jobs_queue_model, F, model(Args));
+model({call, ?MODULE, F, [jobs_queue | Args]}) ->
+    apply(?MODULE, F, model([jobs_queue_model | Args]));
+model({call, ?MODULE, F, Args}) ->
+    apply(?MODULE, F, model(Args));
 model([H|T]) ->
     [model(H) | model(T)];
 model(X) ->
     X.
 
+prop_oldest_job_match() ->
+    ?FORALL(M, g_model(),
+            begin
+                R = eval(M),
+                Repr = jobs_queue:representation(R#model.st),
+                OJ = proplists:get_value(oldest_job, Repr),
+                Cts = proplists:get_value(contents, Repr),
+                case OJ of
+                    undefined ->
+                        Cts == [];
+                    V ->
+                        lists:min([TS || {TS, _} <- Cts]) == V
+                end
+            end).
+
 prop_queue() ->
-    ?FORALL(Q, g_queue(),
+    ?FORALL(M, g_model(),
             equals(
-              catching(fun() -> jobs_queue:representation(
-                                  eval(Q))
+              catching(fun() ->
+                               R = eval(M),
+                               jobs_queue:representation(R#model.st)
                        end, e),
-              catching(fun () -> jobs_queue_model:representation(
-                                   model(Q))
+              catching(fun () ->
+                               R = model(M),
+                               jobs_queue_model:representation(R#model.st)
                        end, q))).
 
 prop_observe() ->
@@ -75,7 +131,7 @@ prop_observe() ->
 catching(F, T) ->
         try F()
         catch C:E ->
-                io:format("Exception: ~p:~p", [C, E]),
+                io:format("Exception: ~p:~p~n", [C, E]),
                 T
         end.
 

--- a/test/jobs_eqc_queue.erl
+++ b/test/jobs_eqc_queue.erl
@@ -27,7 +27,7 @@ g_start_time() ->
          T + N).
 
 g_model_type() ->
-    oneof([jobs_queue]).
+    oneof([jobs_queue, jobs_queue_list]).
 
 g_model(Ty) ->
     ?SIZED(Size, g_model(Size, Ty)).

--- a/test/jobs_queue_model.erl
+++ b/test/jobs_queue_model.erl
@@ -59,7 +59,7 @@ set_oldest_job(fifo, Q) ->
             undefined
     end;
 set_oldest_job(lifo, Q) ->
-    case queue:out_r(Q) of
+    case queue:out(Q) of
         {{value, {TS, _}}, _} ->
             TS;
         {empty, _} ->
@@ -81,7 +81,7 @@ out(lifo, K, Q, Acc) ->
     case queue:out_r(Q) of
         {{value, E}, NQ} ->
             out(lifo, K-1, NQ, [E | Acc]);
-        {emtpy, NQ} ->
+        {empty, NQ} ->
             out(lifo, 0, NQ, Acc)
     end.
 
@@ -96,7 +96,7 @@ representation(#queue { type = fifo, st = Q, oldest_job = OJ} ) ->
      {contents, Cts}];
 representation(#queue { type = lifo, st = Q, oldest_job = OJ} ) ->
     Cts = queue:to_list(queue:reverse(Q)),
-    [{oldest_jobs, OJ},
+    [{oldest_job, OJ},
      {contents, Cts}];
 representation(O) ->
     io:format("Otherwise: ~p", [O]),

--- a/test/jobs_queue_model.erl
+++ b/test/jobs_queue_model.erl
@@ -15,7 +15,16 @@ in(TS, E, #qm { q = Q} = S) ->
 
 out(N, #qm { q = Q} = S) ->
     {Elems, NQ} = out(N, Q, []),
-    {Elems, S#qm { q = NQ}}.
+    S#qm { q = NQ,
+           oj = set_oldest_job(NQ) }.
+
+set_oldest_job(Q) ->
+    case queue:out(Q) of
+        {{value, {TS, _}}, _} ->
+            TS;
+        {empty, _} ->
+            undefined
+    end.
 
 out(0, Q, Taken) ->
     {lists:reverse(Taken), Q};

--- a/test/jobs_queue_model.erl
+++ b/test/jobs_queue_model.erl
@@ -25,9 +25,12 @@ peek(#queue { st = Q }) ->
 all(#queue { st = Q}) ->
     queue:to_list(Q).
 
-in(TS, E, #queue { st = Q} = S) ->
+in(TS, E, #queue { st = Q,
+                   oldest_job = OJ } = S) ->
     S#queue { st = queue:in({TS, E}, Q),
-              oldest_job = TS }.
+              oldest_job = case  OJ of undefined -> TS;
+                               _ -> OJ
+                           end}.
 
 out(N, #queue { st = Q} = S) ->
     {Elems, NQ} = out(N, Q, []),

--- a/test/jobs_queue_model.erl
+++ b/test/jobs_queue_model.erl
@@ -52,6 +52,10 @@ out(K, Q, Acc) when K > 0 ->
             out(0, NQ, Acc)
     end.
 
+empty(#queue {} = Q) ->
+    Q#queue { st = queue:new(),
+              oldest_job = undefined }.
+
 representation(#queue { st = Q, oldest_job = OJ} ) ->
     Cts = queue:to_list(Q),
     [{oldest_job, OJ},

--- a/test/jobs_queue_model.erl
+++ b/test/jobs_queue_model.erl
@@ -1,0 +1,28 @@
+-module(jobs_queue_model).
+
+-compile(export_all).
+
+-record(qm, { type = fifo,
+              q    = queue:new() }).
+
+new(_Options, Q) ->
+    #qm{}.
+
+in(Timestamp, E, #qm { q = Q} = S) ->
+    S#qm { q = queue:in(E, Q)}.
+
+out(N, #qm { q = Q} = S) ->
+    {Elems, NQ} = out(N, Q, []),
+    {Elems, S#qm { q = NQ}}.
+
+out(0, Q, Taken) ->
+    {lists:reverse(Taken), Q};
+out(K, Q, Acc) when K > 0 ->
+    case queue:out(Q) of
+        {{value, E}, NQ} ->
+            out(K-1, NQ, [E | Acc]);
+        {empty, NQ} ->
+            out(0, NQ, Acc)
+    end.
+
+

--- a/test/jobs_queue_model.erl
+++ b/test/jobs_queue_model.erl
@@ -16,6 +16,11 @@ info(max_time, #queue { max_time = MT}) -> MT;
 info(length, #queue { st = Q}) ->
     queue:len(Q).
 
+peek(#queue { st = Q }) ->
+    case queue:peek(Q) of
+        empty -> undefined;
+        {value, K} -> K
+    end.
 
 all(#queue { st = Q}) ->
     queue:to_list(Q).

--- a/test/jobs_queue_model.erl
+++ b/test/jobs_queue_model.erl
@@ -30,9 +30,9 @@ in(TS, E, #queue { st = Q} = S) ->
               oldest_job = TS }.
 
 out(N, #queue { st = Q} = S) ->
-    {_Elems, NQ} = out(N, Q, []),
-    S#queue { st = NQ,
-              oldest_job = set_oldest_job(NQ) }.
+    {Elems, NQ} = out(N, Q, []),
+    {Elems, S#queue { st = NQ,
+                      oldest_job = set_oldest_job(NQ) }}.
 
 set_oldest_job(Q) ->
     case queue:out(Q) of

--- a/test/jobs_queue_model.erl
+++ b/test/jobs_queue_model.erl
@@ -9,6 +9,9 @@
 new(_Options, Q) ->
     #qm{}.
 
+is_empty(#qm { q = Q}) ->
+    queue:is_empty(Q).
+
 in(TS, E, #qm { q = Q} = S) ->
     S#qm { q = queue:in({TS, E}, Q),
            oj = TS }.

--- a/test/jobs_queue_model.erl
+++ b/test/jobs_queue_model.erl
@@ -24,7 +24,8 @@ info(length, #queue { st = Q}) ->
     queue:len(Q).
 
 timedout(#queue { max_time = undefined} = Q) ->
-    {[], Q};
+    %% This return value is highly illogical, but it is what the code returns!
+    [];
 timedout(#queue { max_time = TO, st = Queue} = Q) ->
     Now = jobs_lib:timestamp(),
     QL = queue:to_list(Queue),

--- a/test/jobs_queue_model.erl
+++ b/test/jobs_queue_model.erl
@@ -3,13 +3,15 @@
 -compile(export_all).
 
 -record(qm, { type = fifo,
+              oj   = undefined,
               q    = queue:new() }).
 
 new(_Options, Q) ->
     #qm{}.
 
-in(Timestamp, E, #qm { q = Q} = S) ->
-    S#qm { q = queue:in(E, Q)}.
+in(TS, E, #qm { q = Q} = S) ->
+    S#qm { q = queue:in({TS, E}, Q),
+           oj = TS }.
 
 out(N, #qm { q = Q} = S) ->
     {Elems, NQ} = out(N, Q, []),
@@ -24,5 +26,13 @@ out(K, Q, Acc) when K > 0 ->
         {empty, NQ} ->
             out(0, NQ, Acc)
     end.
+
+representation(#qm { q = Q, oj = OJ} ) ->
+    Cts = queue:to_list(Q),
+    [{oldest_job, OJ},
+     {contents, Cts}];
+representation(O) ->
+    io:format("Otherwise: ~p", [O]),
+    exit(fail).
 
 

--- a/test/t.erl
+++ b/test/t.erl
@@ -3,4 +3,4 @@
 -compile(export_all).
 
 t() ->
-    eqc:module([{numtests, 300}], jobs_eqc_queue).
+    jobs_eqc_queue:test().

--- a/test/t.erl
+++ b/test/t.erl
@@ -3,4 +3,7 @@
 -compile(export_all).
 
 t() ->
-    jobs_eqc_queue:test().
+    t(300).
+
+t(N) ->
+    jobs_eqc_queue:test(N).

--- a/test/t.erl
+++ b/test/t.erl
@@ -3,4 +3,4 @@
 -compile(export_all).
 
 t() ->
-    eqc:module(jobs_eqc_queue).
+    eqc:module([{numtests, 1000}], jobs_eqc_queue).

--- a/test/t.erl
+++ b/test/t.erl
@@ -1,0 +1,6 @@
+-module(t).
+
+-compile(export_all).
+
+t() ->
+    eqc:module(jobs_eqc_queue).

--- a/test/t.erl
+++ b/test/t.erl
@@ -3,4 +3,4 @@
 -compile(export_all).
 
 t() ->
-    eqc:module([{numtests, 1000}], jobs_eqc_queue).
+    eqc:module([{numtests, 300}], jobs_eqc_queue).


### PR DESCRIPTION
Fix `jobs_queue`'s timeout/1,2 calls. Provide EQC model for doing it.

I implemented an EQC model to test `jobs_queue` and `jobs_queue_list`. Everything worked, sans the `jobs_queue` module timedout out from the tail (in) end and not the head (out) end. This is now fixed and we pass 1000 tests routinely. Also while here, fix the calculation of the `oldest_job` value which was also wrong. We can simply ask for it since it is always the head element. A single lookup after evicting a large amount of elements is probably not going to kill us more than to maintain the OJ parameter in `find_expired/N`.

While here, make it possible to observe the queues. And also provide a TODO file for what needs more work.
