### PR TITLE
Fixed crash when rejecting a job

### DIFF
--- a/src/jobs_server.erl
+++ b/src/jobs_server.erl
@@ -1274,7 +1274,8 @@ queue_job(TS, From, #queue{max_size = MaxSz} = Q, S) ->
     if CurSz >= MaxSz ->
             case q_timedout(Q) of
                 [] ->
-                    reject(From);
+                    reject(From),
+                    S;
                 {OldJobs, Q1} ->
                     [timeout(J) || J <- OldJobs],
                     %% update_queue(q_in(TS, From, Q1), S)


### PR DESCRIPTION
jobs_server would crash when queue_job rejected a job proposed for a given queue. The function returned the tuple {error, rejected} instead of the unmodified state record.
