### PR TITLE
Fix jobs:done/1

### DIFF
--- a/src/jobs_server.erl
+++ b/src/jobs_server.erl
@@ -114,7 +114,7 @@ run(Type, Fun) when is_function(Fun, 0) ->
 -spec done(reg_obj()) -> ok.
 %%
 done(Opaque) ->
-    gen_server:cast(?MODULE, {done, Opaque}).
+    gen_server:cast(?MODULE, {done, self(), Opaque}).
 
 
 -spec enqueue(job_class(), any()) -> ok.


### PR DESCRIPTION
Before this change, jobs that ran from the same process would never
be marked "done" because the cast for the done msg never matched.

Things would behave fine provided you spawned a new process for the
duration of the job - calling done/1 didn't do anything, only the
process monitor was correctly cleaning up finished jobs.
