### PR TITLE
update meck version, for erlang 17+

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 
 {deps, [
         {meck, ".*",
-         {git, "git://github.com/eproxus/meck.git", "0.7.2"}},
+         {git, "git://github.com/eproxus/meck.git", "0.8.2"}},
         {parse_trans, ".*",
          {git, "git://github.com/esl/parse_trans.git", "2.8"}},
 	{edown, ".*",


### PR DESCRIPTION
current version of meck specified in rebar.config doesn't build with erlang 17
(meck has warnings_as_errors, a type spec is deprecated)

using latest tag in meck repo fixes it.
